### PR TITLE
Avoid obsolescent features in `push_iterator`

### DIFF
--- a/qcrt/include/util/util_iterator.h
+++ b/qcrt/include/util/util_iterator.h
@@ -6,7 +6,7 @@
 namespace util
 {
     template<class container>
-    class push_iterator : public std::iterator<std::output_iterator_tag, void, void, void, void>
+    class push_iterator
     {	
 
         public:
@@ -15,6 +15,10 @@ namespace util
         typedef container container_type;
         typedef typename container::const_reference const_reference;
         typedef typename container::value_type value_type;
+        typedef std::output_iterator_tag iterator_category;
+        typedef void difference_type;
+        typedef void pointer;
+        typedef void reference;
 
         explicit push_iterator(container& cont)
             : m_container(&cont)
@@ -60,6 +64,7 @@ namespace util
     };
 }
 
+#if defined(_MSC_VER) && _MSC_VER < 1915
 namespace std
 {
     template<class container>
@@ -69,5 +74,6 @@ namespace std
         // mark push_iterator as checked
     };
 }
+#endif
 
 #endif


### PR DESCRIPTION
1. `std::iterator` is deprecated in C++17 (see [cppreference](https://en.cppreference.com/w/cpp/iterator/iterator) and [P0174R2](https://wg21.link/p0174r2)). It's better to explicitly provide the member typedef-names and avoid inheritance.
2. `_Is_checked_helper` became meaningless since VS 2017 15.8/19.15. Removal of it is planned in microsoft/STL#5081. I think we should stop using it for newer versions of MSVC.